### PR TITLE
Remove unnecessary filters on posts loop

### DIFF
--- a/wp-post-expires.php
+++ b/wp-post-expires.php
@@ -265,6 +265,10 @@ class XNPostExpires {
             } else {
                 add_filter('display_post_states', [$this, 'addPostState'], 10, 2);
             }
+        } else {
+            remove_filter('the_title', [$this, 'textTitleFilter'], 10, 2);
+            remove_filter('post_class', [$this, 'cssClassFilter']);
+            remove_filter('display_post_states', [$this, 'addPostState'], 10, 2);
         }
     }
 


### PR DESCRIPTION
Resolve bug: posts marked as expired even when they’re not.
More info: https://wordpress.org/support/topic/bug-posts-marked-as-expired-even-when-theyre-not/